### PR TITLE
Provide option to use validation rules on unauthenticated users who m…

### DIFF
--- a/CRM/Membershipextra/Upgrader.php
+++ b/CRM/Membershipextra/Upgrader.php
@@ -32,119 +32,36 @@ class CRM_Membershipextra_Upgrader extends CRM_Membershipextra_Upgrader_Base {
       CRM_Core_Error::debug_log_message($msg, FALSE, 'com.skvare.membershipextra');
     }
   }
-  /**
-   * Example: Work with entities usually not available during the install step.
-   *
-   * This method can be used for any post-install tasks. For example, if a step
-   * of your installation depends on accessing an entity that is itself
-   * created during the installation (e.g., a setting or a managed entity), do
-   * so here to avoid order of operation problems.
-   *
-  public function postInstall() {
-    $customFieldId = civicrm_api3('CustomField', 'getvalue', array(
-      'return' => array("id"),
-      'name' => "customFieldCreatedViaManagedHook",
-    ));
-    civicrm_api3('Setting', 'create', array(
-      'myWeirdFieldSetting' => array('id' => $customFieldId, 'weirdness' => 1),
-    ));
-  }
 
-  /**
-   * Example: Run an external SQL script when the module is uninstalled.
-   *
-  public function uninstall() {
-   $this->executeSqlFile('sql/myuninstall.sql');
-  }
+  public function upgrade_1001() {
+    $this->ctx->log->info('Applying update 1001');
 
-  /**
-   * Example: Run a simple query when a module is enabled.
-   *
-  public function enable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
-  }
+    $allCiviSettings = Civi::settings()->all();
 
-  /**
-   * Example: Run a simple query when a module is disabled.
-   *
-  public function disable() {
-    CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
-  }
+    $ourNewSettingsNames = CRM_Membershipextra_Utils::getSettingsNames();
+    $ourSettingsNames =
+      array_combine($ourNewSettingsNames, $ourNewSettingsNames)
+      + [
+        'allow_renewal_before' => 'renewal_period_number',
+        'allow_renewal_before_unit' => 'renewal_period_unit',
+      ];
 
-  /**
-   * Example: Run a couple simple queries.
-   *
-   * @return TRUE on success
-   * @throws Exception
-   *
-  public function upgrade_4200() {
-    $this->ctx->log->info('Applying update 4200');
-    CRM_Core_DAO::executeQuery('UPDATE foo SET bar = "whiz"');
-    CRM_Core_DAO::executeQuery('DELETE FROM bang WHERE willy = wonka(2)');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run an external SQL script.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4201() {
-    $this->ctx->log->info('Applying update 4201');
-    // this path is relative to the extension base dir
-    $this->executeSqlFile('sql/upgrade_4201.sql');
-    return TRUE;
-  } // */
-
-
-  /**
-   * Example: Run a slow upgrade process by breaking it up into smaller chunk.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4202() {
-    $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
-
-    $this->addTask(E::ts('Process first step'), 'processPart1', $arg1, $arg2);
-    $this->addTask(E::ts('Process second step'), 'processPart2', $arg3, $arg4);
-    $this->addTask(E::ts('Process second step'), 'processPart3', $arg5);
-    return TRUE;
-  }
-  public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
-  public function processPart2($arg3, $arg4) { sleep(10); return TRUE; }
-  public function processPart3($arg5) { sleep(10); return TRUE; }
-  // */
-
-
-  /**
-   * Example: Run an upgrade with a query that touches many (potentially
-   * millions) of records by breaking it up into smaller chunks.
-   *
-   * @return TRUE on success
-   * @throws Exception
-  public function upgrade_4203() {
-    $this->ctx->log->info('Planning update 4203'); // PEAR Log interface
-
-    $minId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(min(id),0) FROM civicrm_contribution');
-    $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
-    for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
-      $endId = $startId + self::BATCH_SIZE - 1;
-      $title = E::ts('Upgrade Batch (%1 => %2)', array(
-        1 => $startId,
-        2 => $endId,
-      ));
-      $sql = '
-        UPDATE civicrm_contribution SET foobar = whiz(wonky()+wanker)
-        WHERE id BETWEEN %1 and %2
-      ';
-      $params = array(
-        1 => array($startId, 'Integer'),
-        2 => array($endId, 'Integer'),
-      );
-      $this->addTask($title, 'executeSql', $sql, $params);
+    foreach ($ourSettingsNames as $ourSettingName => $ourNewSettingName) {
+      $nameLen = strlen($ourSettingName);
+      foreach ($allCiviSettings as $existingKey => $value) {
+        if (substr($existingKey, 0, $nameLen) === $ourSettingName) {
+          $membershipTypeID = substr($existingKey, $nameLen + 1);
+          if (!is_numeric($membershipTypeID)) {
+            continue;
+          }
+          $newKey = "Membershipextra:$ourNewSettingName:$membershipTypeID";
+          Civi::settings()->set($newKey, $value);
+          Civi::settings()->revert($existingKey);
+        }
+      }
     }
+
     return TRUE;
-  } // */
+  }
 
 }

--- a/CRM/Membershipextra/Utils.php
+++ b/CRM/Membershipextra/Utils.php
@@ -45,11 +45,11 @@ class CRM_Membershipextra_Utils {
       if (!is_array($fee['options'])) {
         continue;
       }
-      foreach ($fee['options'] as $option) {
+      foreach ($fee['options'] as $option_id => $option) {
         // if priceset contain the membership type, then proceed.
         if (isset($option['membership_type_id'])) {
           $membershipTypeId = $option['membership_type_id'];
-          $formMembershipTypeIds[$option['price_field_id']] = $membershipTypeId;
+          $formMembershipTypeIds[$option_id] = $membershipTypeId;
 
           // get Custom Setting for each Membership type
           $membershipExtras[$membershipTypeId] = CRM_Membershipextra_Utils::getSettings($membershipTypeId);

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/Skvare/com.skvare.membershipextra</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-08-30</releaseDate>
-  <version>1.0</version>
+  <releaseDate>2021-06-15</releaseDate>
+  <version>1.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.21</ver>

--- a/templates/CRM/Member/Form/MembershipType.extra.tpl
+++ b/templates/CRM/Member/Form/MembershipType.extra.tpl
@@ -1,6 +1,7 @@
 {literal}
     <script type="text/javascript">
         CRM.$(function($) {
+            $('.crm-membership-type-form-block-check_unauthenticated_contacts').insertAfter('.crm-membership-type-form-block-period_type');
             $('.crm-membership-type-form-block-limit_renewal').insertAfter('.crm-membership-type-form-block-period_type');
             $('.crm-membership-type-form-block-renewal_period').insertAfter('.crm-membership-type-form-block-period_type');
             $('.crm-membership-type-form-block-restrict_to_groups').insertAfter('.crm-membership-type-form-block-period_type');
@@ -50,6 +51,17 @@
         <td>{$form.restrict_to_groups.html}<br/>
             <span class="description">
                 {ts}On public contribution pages, disallow signup/renewal by contacts not in these groups.{/ts}
+            </span>
+            <br/><br/>
+        </td>
+    </tr>
+    <tr class="crm-membership-type-form-block-check_unauthenticated_contacts">
+        <td class="label">{$form.check_unauthenticated_contacts.label}</td>
+        <td>{$form.check_unauthenticated_contacts.html}<br/>
+            <span class="description">
+                {ts}PRIVACY WARNING: applying signup/renewal restrictions to form submissions by unauthenticated
+                    users may decrease the privacy of your members. Anyone submitting the form will know
+                    whether there is an active membership associated with the submitted contact information.{/ts}
             </span>
             <br/><br/>
         </td>


### PR DESCRIPTION
Hi Sunil,

I made the changes in this PR because my client needs to restrict membership renewals even for users who aren't logged in. I hope you will see the changes as improvements.

The PR adds a checkbox to the Membership Type form, allowing admins to choose this new behaviour.

To support this, the PR includes:

- modernized handling of settings (using `Civi::settings()` now)
- some additional template code
- a small amount of new logic (adapted from some code which you wrote but commented out)

It also includes some miscellaneous code cleanup, fixing typos, removing unused variables, light refactoring etc. Unfortunately my IDE, PHPStorm, also reformatted a large number of lines, and that's why the PR looks so big. It is really not very big, functionally.