### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.2</version>
   <develStage>alpha</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>This is a new, undeveloped module</comments>
   <civix>

--- a/templates/CRM/Membershipextra/Form/Search/Membership.tpl
+++ b/templates/CRM/Membershipextra/Form/Search/Membership.tpl
@@ -84,7 +84,7 @@
                     {/if}
 
                     {strip}
-                        <table class="selector row-highlight" summary="{ts}Search results listings.{/ts}">
+                        <table class="selector row-highlight" summary="{ts escape='htmlattribute'}Search results listings.{/ts}">
                             <thead class="sticky">
                             <tr>
                                 <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.