### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Membershipextra/Form/Report/Member/MembershipDonation.php
+++ b/CRM/Membershipextra/Form/Report/Member/MembershipDonation.php
@@ -320,8 +320,8 @@ class CRM_Membershipextra_Form_Report_Member_MembershipDonation extends CRM_Repo
             }
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
           }
         }
       }
@@ -397,8 +397,8 @@ class CRM_Membershipextra_Form_Report_Member_MembershipDonation extends CRM_Repo
         if (array_key_exists('fields', $table)) {
           foreach ($table['fields'] as $fieldName => $field) {
             if (!empty($field['csv_display']) && !empty($field['no_display'])) {
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
           }
         }
@@ -476,19 +476,19 @@ class CRM_Membershipextra_Form_Report_Member_MembershipDonation extends CRM_Repo
         $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Summary for this Contact.');
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      if ($value = $row['civicrm_contribution_financial_type_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
+      if ($value = $row['civicrm_contribution_payment_instrument_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }
-      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount_sum', $row)) &&
+      if (($value = $row['civicrm_contribution_total_amount_sum'] ?? NULL) &&
         CRM_Core_Permission::check('access CiviContribute')
       ) {
         $url = CRM_Utils_System::url('civicrm/contact/view/contribution',

--- a/CRM/Membershipextra/Form/Report/Member/Renewal.php
+++ b/CRM/Membershipextra/Form/Report/Member/Renewal.php
@@ -298,7 +298,7 @@ class CRM_Membershipextra_Form_Report_Member_Renewal extends CRM_Report_Form {
             if (array_key_exists('title', $field)) {
               $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'];
             }
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
           }
         }
       }
@@ -457,15 +457,15 @@ class CRM_Membershipextra_Form_Report_Member_Renewal extends CRM_Report_Form {
         $entryFound = TRUE;
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      if ($value = $row['civicrm_contribution_financial_type_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
+      if ($value = $row['civicrm_contribution_payment_instrument_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }

--- a/CRM/Membershipextra/Form/Report/Member/SeparateMembershipamount.php
+++ b/CRM/Membershipextra/Form/Report/Member/SeparateMembershipamount.php
@@ -298,8 +298,8 @@ class CRM_Membershipextra_Form_Report_Member_SeparateMembershipamount extends CR
             }
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
           }
         }
       }
@@ -371,8 +371,8 @@ class CRM_Membershipextra_Form_Report_Member_SeparateMembershipamount extends CR
         if (array_key_exists('fields', $table)) {
           foreach ($table['fields'] as $fieldName => $field) {
             if (!empty($field['csv_display']) && !empty($field['no_display'])) {
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
           }
         }
@@ -450,19 +450,19 @@ class CRM_Membershipextra_Form_Report_Member_SeparateMembershipamount extends CR
         $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Summary for this Contact.');
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      if ($value = $row['civicrm_contribution_financial_type_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
+      if ($value = $row['civicrm_contribution_payment_instrument_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }
-      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount_sum', $row)) &&
+      if (($value = $row['civicrm_contribution_total_amount_sum'] ?? NULL) &&
         CRM_Core_Permission::check('access CiviContribute')
       ) {
         $url = CRM_Utils_System::url('civicrm/contact/view/contribution',

--- a/CRM/Membershipextra/Form/Report/Member/SeparateMembershipamountTest.php
+++ b/CRM/Membershipextra/Form/Report/Member/SeparateMembershipamountTest.php
@@ -304,8 +304,8 @@ class CRM_Membershipextra_Form_Report_Member_SeparateMembershipamountTest extend
             }
 
             $select[] = "{$field['dbAlias']} as {$tableName}_{$fieldName}";
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+            $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
           }
         }
       }
@@ -440,8 +440,8 @@ class CRM_Membershipextra_Form_Report_Member_SeparateMembershipamountTest extend
         if (array_key_exists('fields', $table)) {
           foreach ($table['fields'] as $fieldName => $field) {
             if (!empty($field['csv_display']) && !empty($field['no_display'])) {
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = CRM_Utils_Array::value('title', $field);
-              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = CRM_Utils_Array::value('type', $field);
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;
+              $this->_columnHeaders["{$tableName}_{$fieldName}"]['type'] = $field['type'] ?? NULL;
             }
           }
         }
@@ -519,19 +519,19 @@ class CRM_Membershipextra_Form_Report_Member_SeparateMembershipamountTest extend
         $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts('View Contact Summary for this Contact.');
       }
 
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_financial_type_id', $row)) {
+      if ($value = $row['civicrm_contribution_financial_type_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_financial_type_id'] = $contributionTypes[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_contribution_status_id'] = $contributionStatus[$value];
         $entryFound = TRUE;
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_payment_instrument_id', $row)) {
+      if ($value = $row['civicrm_contribution_payment_instrument_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_payment_instrument_id'] = $paymentInstruments[$value];
         $entryFound = TRUE;
       }
-      if (($value = CRM_Utils_Array::value('civicrm_contribution_total_amount_sum', $row)) &&
+      if (($value = $row['civicrm_contribution_total_amount_sum'] ?? NULL) &&
         CRM_Core_Permission::check('access CiviContribute')
       ) {
         $url = CRM_Utils_System::url('civicrm/contact/view/contribution',

--- a/CRM/Membershipextra/Form/Search/Membership.php
+++ b/CRM/Membershipextra/Form/Search/Membership.php
@@ -31,14 +31,14 @@ class CRM_Membershipextra_Form_Search_Membership extends CRM_Contact_Form_Search
     $this->_memStatus = CRM_Utils_Array::value('memStatus', $this->_formValues, []);
     $this->_excludeMemStatus = CRM_Utils_Array::value('excludeMemStatus', $this->_formValues, []);
 
-    $this->_memSinceFrom = CRM_Utils_Array::value('member_join_date_low', $this->_formValues);
-    $this->_memSinceTo = CRM_Utils_Array::value('member_join_date_high', $this->_formValues);
+    $this->_memSinceFrom = $this->_formValues['member_join_date_low'] ?? NULL;
+    $this->_memSinceTo = $this->_formValues['member_join_date_high'] ?? NULL;
 
-    $this->_memStartFrom = CRM_Utils_Array::value('member_start_date_low', $this->_formValues);
-    $this->_memStartTo = CRM_Utils_Array::value('member_start_date_high', $this->_formValues);
+    $this->_memStartFrom = $this->_formValues['member_start_date_low'] ?? NULL;
+    $this->_memStartTo = $this->_formValues['member_start_date_high'] ?? NULL;
 
-    $this->_memEndFrom = CRM_Utils_Array::value('member_end_date_low', $this->_formValues);
-    $this->_memEndTo = CRM_Utils_Array::value('member_end_date_high', $this->_formValues);
+    $this->_memEndFrom = $this->_formValues['member_end_date_low'] ?? NULL;
+    $this->_memEndTo = $this->_formValues['member_end_date_high'] ?? NULL;
 
     list($this->_memSinceFrom, $this->_memSinceTo) = $this->getFromTo(CRM_Utils_Array::value('member_join_date_relative', $this->_formValues), $this->_memSinceFrom, $this->_memSinceTo);
     list($this->_memStartFrom, $this->_memStartTo) = $this->getFromTo(CRM_Utils_Array::value('member_start_date_relative', $this->_formValues), $this->_memStartFrom, $this->_memStartTo);
@@ -109,22 +109,22 @@ class CRM_Membershipextra_Form_Search_Membership extends CRM_Contact_Form_Search
    */
   public function setDefaultValues() {
     if (!empty($this->_formValues)) {
-      $defaults['includeMemTypes'] = CRM_Utils_Array::value('includeMemTypes', $this->_formValues);
-      $defaults['excludeMemTypes'] = CRM_Utils_Array::value('excludeMemTypes', $this->_formValues);
-      $defaults['memStatus'] = CRM_Utils_Array::value('memStatus', $this->_formValues);
-      $defaults['excludeMemStatus'] = CRM_Utils_Array::value('excludeMemStatus', $this->_formValues);
+      $defaults['includeMemTypes'] = $this->_formValues['includeMemTypes'] ?? NULL;
+      $defaults['excludeMemTypes'] = $this->_formValues['excludeMemTypes'] ?? NULL;
+      $defaults['memStatus'] = $this->_formValues['memStatus'] ?? NULL;
+      $defaults['excludeMemStatus'] = $this->_formValues['excludeMemStatus'] ?? NULL;
 
-      $defaults['member_join_date_low'] = CRM_Utils_Array::value('member_join_date_low', $this->_formValues);
-      $defaults['member_join_date_high'] = CRM_Utils_Array::value('member_join_date_high', $this->_formValues);
-      $defaults['member_join_date_relative'] = CRM_Utils_Array::value('member_join_date_relative', $this->_formValues);
+      $defaults['member_join_date_low'] = $this->_formValues['member_join_date_low'] ?? NULL;
+      $defaults['member_join_date_high'] = $this->_formValues['member_join_date_high'] ?? NULL;
+      $defaults['member_join_date_relative'] = $this->_formValues['member_join_date_relative'] ?? NULL;
 
-      $defaults['member_start_date_low'] = CRM_Utils_Array::value('member_start_date_low', $this->_formValues);
-      $defaults['member_start_date_high'] = CRM_Utils_Array::value('member_start_date_high', $this->_formValues);
-      $defaults['member_start_date_relative'] = CRM_Utils_Array::value('member_start_date_relative', $this->_formValues);
+      $defaults['member_start_date_low'] = $this->_formValues['member_start_date_low'] ?? NULL;
+      $defaults['member_start_date_high'] = $this->_formValues['member_start_date_high'] ?? NULL;
+      $defaults['member_start_date_relative'] = $this->_formValues['member_start_date_relative'] ?? NULL;
 
-      $defaults['member_end_date_low'] = CRM_Utils_Array::value('member_end_date_low', $this->_formValues);
-      $defaults['member_end_date_high'] = CRM_Utils_Array::value('member_end_date_high', $this->_formValues);
-      $defaults['member_end_date_relative'] = CRM_Utils_Array::value('member_end_date_relative', $this->_formValues);
+      $defaults['member_end_date_low'] = $this->_formValues['member_end_date_low'] ?? NULL;
+      $defaults['member_end_date_high'] = $this->_formValues['member_end_date_high'] ?? NULL;
+      $defaults['member_end_date_relative'] = $this->_formValues['member_end_date_relative'] ?? NULL;
     }
 
     return $defaults;

--- a/CRM/Membershipextra/Utils.php
+++ b/CRM/Membershipextra/Utils.php
@@ -69,7 +69,7 @@ class CRM_Membershipextra_Utils {
             $membershipExtras[$membershipTypeId]['period_type'] = 'fixed';
             $membershipExtras[$membershipTypeId]['duration_unit'] = $membershipExtrasDetails['duration_unit'];
             $membershipExtras[$membershipTypeId]['duration_interval'] = $membershipExtrasDetails['duration_interval'];
-            $membershipExtras[$membershipTypeId]['fixed_period_start_day'] = CRM_Utils_Array::value('fixed_period_start_day', $membershipExtrasDetails);
+            $membershipExtras[$membershipTypeId]['fixed_period_start_day'] = $membershipExtrasDetails['fixed_period_start_day'] ?? NULL;
             $membershipExtras[$membershipTypeId]['fixed_period_rollover_day'] = $membershipExtrasDetails['fixed_period_rollover_day'];
 
             // unset custom field belong to rolling type


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.